### PR TITLE
Check PID algorithm in APP_PWMB_Output.c

### DIFF
--- a/App/src/APP_PWMB_Output.c
+++ b/App/src/APP_PWMB_Output.c
@@ -207,8 +207,8 @@ float PID_Choice(
     
 
     
-    // 计算偏差 - 修复误差计算逻辑
-    err_now = (float)(User_Target - current); // 直接计算误差：目标值 - 当前值
+    // 计算偏差 - 先转为浮点再相减，避免无符号减法导致的下溢
+    err_now = (float)User_Target - (float)current; // 误差 = 目标值 - 当前值
     
     // 更新积分项
     deviation_SUM += err_now;    // 误差累加


### PR DESCRIPTION
Fix PID error calculation to prevent unsigned underflow and incorrect output.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b566ec7-8efc-4b10-8e90-c52cdc26d39e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b566ec7-8efc-4b10-8e90-c52cdc26d39e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

